### PR TITLE
SC62199: Add settings storage to apps SDK

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deskpro/app-sdk",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Deskpro Apps SDK",
   "private": false,
   "license": "proprietary",

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -77,6 +77,10 @@ export class DeskproClient implements IDeskproClient {
   public deleteState: (name: string) => Promise<boolean>;
   public deleteUserState: (name: string) => Promise<boolean>;
 
+  // Settings
+  public setSetting: <T>(name: string, value: T) => Promise<void>;
+  public setSettings: (settings: Record<string, any>) => Promise<void>;
+
   constructor(
     private readonly parent: <T extends object = CallSender>(options?: object) => Connection<T>,
     private readonly options: DeskproClientOptions
@@ -100,6 +104,9 @@ export class DeskproClient implements IDeskproClient {
     this.getUserState = async () => [];
     this.deleteState = async () => false;
     this.deleteUserState = async () => false;
+
+    this.setSetting = async () => {};
+    this.setSettings = async () => {};
 
     if (this.options.runAfterPageLoad) {
       window.addEventListener("load", () => this.run());
@@ -199,6 +206,15 @@ export class DeskproClient implements IDeskproClient {
 
     if (parent._userStateDelete) {
       this.deleteUserState = parent._userStateDelete;
+    }
+
+    // Settings
+    if (parent._settingSet) {
+      this.setSetting = <T>(name: string, value: T) => parent._settingSet(name, JSON.stringify(value));
+    }
+
+    if (parent._settingsSet) {
+      this.setSettings = (settings: Record<string, any>) => parent._settingsSet(JSON.stringify(settings));
     }
   }
 

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -86,6 +86,8 @@ export interface CoreCallSender {
   _userStateGet: (name: string) => Promise<any>;
   _stateDelete: (name: string) => Promise<any>;
   _userStateDelete: (name: string) => Promise<any>;
+  _settingSet: (name: string, value: string) => Promise<any>;
+  _settingsSet: (settings: string) => Promise<any>;
 }
 
 export type DeskproCallSender = CoreCallSender & TicketSidebarDeskproCallSender;
@@ -170,6 +172,8 @@ export interface IDeskproClient {
   getUserState: <T>(name: string) => Promise<GetStateResponse<T>[]>;
   deleteState: (name: string) => Promise<boolean>;
   deleteUserState: (name: string) => Promise<boolean>;
+  setSetting: <T>(name: string, value: T) => Promise<void>;
+  setSettings: (settings: Record<string, any>) => Promise<void>;
   getEntityAssociation(name: string, entityId: string): IEntityAssociation;
 }
 


### PR DESCRIPTION
Link to Shortcut: https://app.shortcut.com/deskpro/story/62199/add-settings-storage-to-apps-sdk