### PR TITLE
Moved react and styled-components to peer deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,11 @@
     "cjs",
     "README.md"
   ],
+  "peerDependencies": {
+    "react": "^17 || ^18",
+    "react-dom": "^17 || ^18",
+    "styled-components": "^5"
+  },
   "engines": {
     "node": "^16.0.0"
   },
@@ -25,13 +30,10 @@
     "handlebars": "4.7.7",
     "modern-normalize": "^1.1.0",
     "penpal": "6.2.1",
-    "react": "17.0.2",
-    "react-dom": "17.0.2",
     "react-flatpickr": "3.10.7",
-    "react-intl": "5.23.0",
+    "react-intl": "^5.23.0",
     "regenerator-runtime": "0.13.9",
     "shortcut-buttons-flatpickr": "0.4.0",
-    "styled-components": "5.3.3",
     "tslib": "2.3.1"
   },
   "devDependencies": {
@@ -63,6 +65,8 @@
     "fast-glob": "3.2.7",
     "jest": "27.4.4",
     "node-sass": "7.0.0",
+    "react": "^17.0.2",
+    "react-dom": "^17.0.2",
     "rollup": "2.61.0",
     "rollup-plugin-babel": "4.4.0",
     "rollup-plugin-commonjs": "10.1.0",
@@ -75,6 +79,7 @@
     "rollup-plugin-terser": "7.0.2",
     "rollup-plugin-typescript": "1.0.1",
     "scss-reset": "1.2.2",
+    "styled-components": "^5.3.3",
     "terser": "5.10.0",
     "typescript": "^4.6.4"
   },


### PR DESCRIPTION
Moved `react`, `react-dom`, and `styled-components` to being peer dependencies and widened their semver compat to cover react 17 and 18. Also added them to dev dependencies for local development.
