### PR TITLE
Add Height Wrapper

### DIFF
--- a/src/ui/context/DeskproAppProvider.tsx
+++ b/src/ui/context/DeskproAppProvider.tsx
@@ -5,10 +5,15 @@ import { createClient } from "../../client/client";
 import { Context, IDeskproClient, TargetAction, TargetElementEvent } from "../../client/types";
 import { DeskproAppContext } from "./context";
 import { ThemeProvider } from "@deskpro/deskpro-ui";
+import { HeightWrapper } from "./SetHeightWrapper";
 
-export const DeskproAppProvider: FC<DeskproAppProviderProps> = ({ children, theme, debug }: DeskproAppProviderProps) => {
-  const [client, setClient] = useState<IDeskproClient|null>(null);
-  const [context, setContext] = useState<Context|null>(null);
+export const DeskproAppProvider: FC<DeskproAppProviderProps> = ({
+  children,
+  theme,
+  debug,
+}: DeskproAppProviderProps) => {
+  const [client, setClient] = useState<IDeskproClient | null>(null);
+  const [context, setContext] = useState<Context | null>(null);
   const [registeredElements, setRegisteredElements] = useState<string[]>([]);
 
   useEffect(() => {
@@ -51,26 +56,28 @@ export const DeskproAppProvider: FC<DeskproAppProviderProps> = ({ children, them
 
     dpClient.onElementEvent((id, type, payload) => {
       document.dispatchEvent(
-        new CustomEvent<TargetElementEvent>(DeskproAppEventType.TARGET_ELEMENT_EVENT, { detail: {id, type, payload} as TargetElementEvent })
+        new CustomEvent<TargetElementEvent>(DeskproAppEventType.TARGET_ELEMENT_EVENT, {
+          detail: { id, type, payload } as TargetElementEvent,
+        })
       );
     });
 
     dpClient.onAdminSettingsChange((settings) => {
       setContext({ type: "admin_settings", settings }); // Pass more admin context here if we ever have one
       document.dispatchEvent(
-          new CustomEvent<Record<string, any>>(DeskproAppEventType.ADMIN_SETTINGS_CHANGE, { detail: settings })
+        new CustomEvent<Record<string, any>>(DeskproAppEventType.ADMIN_SETTINGS_CHANGE, {
+          detail: settings,
+        })
       );
     });
 
     dpClient.run().then(() => setClient(dpClient));
-  // eslint-disable-next-line react-hooks/exhaustive-deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   if (debug) {
     console.debug(
-        client
-            ? "Deskpro apps client is ready"
-            : "Deskpro apps client is initialising..."
+      client ? "Deskpro apps client is ready" : "Deskpro apps client is initialising..."
     );
   }
 
@@ -79,8 +86,10 @@ export const DeskproAppProvider: FC<DeskproAppProviderProps> = ({ children, them
   return (
     <ThemeProvider theme={currentTheme}>
       <GlobalStyles />
-      <DeskproAppContext.Provider value={{ client, context, registeredElements, setRegisteredElements, theme: currentTheme }}>
-        {children}
+      <DeskproAppContext.Provider
+        value={{ client, context, registeredElements, setRegisteredElements, theme: currentTheme }}
+      >
+        <HeightWrapper>{children}</HeightWrapper>
       </DeskproAppContext.Provider>
     </ThemeProvider>
   );

--- a/src/ui/context/SetHeightWrapper.tsx
+++ b/src/ui/context/SetHeightWrapper.tsx
@@ -1,0 +1,21 @@
+import { useDeskproAppClient } from "./hooks";
+import React, { useEffect, useRef } from "react";
+
+export const HeightWrapper = ({ children }: { children: React.ReactNode }) => {
+  const { client } = useDeskproAppClient();
+  const ref = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    if (!ref.current) return;
+    const body = document.body;
+    const styles = window.getComputedStyle(body);
+    const marginTop = styles.getPropertyValue("margin-top");
+    const marginBottom = styles.getPropertyValue("margin-bottom");
+    const additionalHeight = parseInt(marginTop) ?? 0 + parseInt(marginBottom) ?? 0;
+    const resizeObserver = new ResizeObserver(() => {
+      client?.setHeight(document.body.scrollHeight + additionalHeight);
+    });
+    resizeObserver.observe(ref.current);
+    return () => resizeObserver.disconnect(); // clean up
+  }, [client]);
+  return <div ref={ref}>{children}</div>;
+};


### PR DESCRIPTION
In this PR we add a wrapper component that mounts a resize observer, measures the document body's scroll height and margin, and reports this to the client's `setHeight` callback in order to remove `iframe-resizer` as a dependency from horizon due to an unfixed memory leak in that package.