### PR TITLE
[Feature] SC-123527 Optimise storage of app assets for on-prem

### DIFF
--- a/.github/workflows/master.yaml
+++ b/.github/workflows/master.yaml
@@ -66,14 +66,14 @@ jobs:
           fi
 
           if [[ "${{ steps.labels.outputs.milestone }}" == "major-version" ]]; then
-            npm version major
+            pnpm version major
           elif [[ "${{ steps.labels.outputs.milestone }}" == "minor-version" ]]; then
-            npm version minor
+            pnpm version minor
           else
-            npm version patch
+            pnpm version patch
           fi
 
-          npm run docs:storybook
+          pnpm run docs:storybook
 
           git add docs/*
 
@@ -81,12 +81,12 @@ jobs:
 
           git push origin master
 
-      - name: Authenticate NPM
+      - name: Authenticate Registry
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
-        run: echo "//registry.npmjs.org/:_authToken=$NODE_AUTH_TOKEN" > .npmrc
+        run: pnpm config set //registry.npmjs.org/:_authToken $NODE_AUTH_TOKEN
 
-      - name: Publish to NPM
+      - name: Publish to Registry
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
-        run: npm publish
+        run: pnpm publish

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ styles and utilities for use in simple apps and widgets.
 
 ## Installation
 
-Install the SDK via PNPM or NPM:
+Install the SDK via `pnpm` or `npm`:
 
 ```bash
 pnpm add @deskpro/app-sdk

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "README.md"
   ],
   "peerDependencies": {
-    "@deskpro/deskpro-ui": "^7",
+    "@deskpro/deskpro-ui": "^8",
     "@types/react": "^18",
     "@types/react-dom": "^18",
     "react": "^18",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "node": ">=20.0.0"
   },
   "dependencies": {
-    "@deskpro/deskpro-ui": "^7.18.0",
+    "@deskpro/deskpro-ui": "^8.0.0",
     "@fortawesome/fontawesome-svg-core": "^6.4.0",
     "@fortawesome/free-brands-svg-icons": "^6.4.0",
     "@fortawesome/free-regular-svg-icons": "^6.4.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@deskpro/deskpro-ui':
-        specifier: ^7.18.0
-        version: 7.18.0(@types/web@0.0.111)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(styled-components@5.3.11(@babel/core@7.16.0)(react-dom@18.2.0(react@18.2.0))(react-is@18.2.0)(react@18.2.0))
+        specifier: ^8.0.0
+        version: 8.0.0(@types/web@0.0.111)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(styled-components@5.3.11(@babel/core@7.16.0)(react-dom@18.2.0(react@18.2.0))(react-is@18.3.1)(react@18.2.0))
       '@fortawesome/fontawesome-svg-core':
         specifier: ^6.4.0
         version: 6.5.1
@@ -82,7 +82,7 @@ importers:
         version: 0.4.0
       styled-components:
         specifier: ^5.3.11
-        version: 5.3.11(@babel/core@7.16.0)(react-dom@18.2.0(react@18.2.0))(react-is@18.2.0)(react@18.2.0)
+        version: 5.3.11(@babel/core@7.16.0)(react-dom@18.2.0(react@18.2.0))(react-is@18.3.1)(react@18.2.0)
       ts-pattern:
         specifier: ^4.3.0
         version: 4.3.0
@@ -1432,9 +1432,9 @@ packages:
   '@bcoe/v8-coverage@0.2.3':
     resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
 
-  '@deskpro/deskpro-ui@7.18.0':
-    resolution: {integrity: sha512-UliZbZXcLE2QpG+DmNzFkm8n+na2kCyfMiaKuy4fNMCmkYl9pftnBEbK4TxM7OOUiem+wo2/CHM2/C6WD6uYXw==}
-    engines: {node: ^16.0.0}
+  '@deskpro/deskpro-ui@8.0.0':
+    resolution: {integrity: sha512-6H9mqFxXnjQz6rBE16cVbyOxdsxaZ2kPJA4ZnpvzMAN6V1HlBTkPnlKn7oUiMyAw59sMp7acAE+CREyHe9Nphw==}
+    engines: {node: '>= 20.16.0'}
     peerDependencies:
       '@typescript/lib-dom': npm:@types/web
       react: ^18
@@ -1804,23 +1804,23 @@ packages:
       '@types/react': '>=16'
       react: '>=16'
 
-  '@motionone/animation@10.17.0':
-    resolution: {integrity: sha512-ANfIN9+iq1kGgsZxs+Nz96uiNcPLGTXwfNo2Xz/fcJXniPYpaz/Uyrfa+7I5BPLxCP82sh7quVDudf1GABqHbg==}
+  '@motionone/animation@10.18.0':
+    resolution: {integrity: sha512-9z2p5GFGCm0gBsZbi8rVMOAJCtw1WqBTIPw3ozk06gDvZInBPIsQcHgYogEJ4yuHJ+akuW8g1SEIOpTOvYs8hw==}
 
   '@motionone/dom@10.12.0':
     resolution: {integrity: sha512-UdPTtLMAktHiqV0atOczNYyDd/d8Cf5fFsd1tua03PqTwwCe/6lwhLSQ8a7TbnQ5SN0gm44N1slBfj+ORIhrqw==}
 
-  '@motionone/easing@10.17.0':
-    resolution: {integrity: sha512-Bxe2wSuLu/qxqW4rBFS5m9tMLOw+QBh8v5A7Z5k4Ul4sTj5jAOfZG5R0bn5ywmk+Fs92Ij1feZ5pmC4TeXA8Tg==}
+  '@motionone/easing@10.18.0':
+    resolution: {integrity: sha512-VcjByo7XpdLS4o9T8t99JtgxkdMcNWD3yHU/n6CLEz3bkmKDRZyYQ/wmSf6daum8ZXqfUAgFeCZSpJZIMxaCzg==}
 
-  '@motionone/generators@10.17.0':
-    resolution: {integrity: sha512-T6Uo5bDHrZWhIfxG/2Aut7qyWQyJIWehk6OB4qNvr/jwA/SRmixwbd7SOrxZi1z5rH3LIeFFBKK1xHnSbGPZSQ==}
+  '@motionone/generators@10.18.0':
+    resolution: {integrity: sha512-+qfkC2DtkDj4tHPu+AFKVfR/C30O1vYdvsGYaR13W/1cczPrrcjdvYCj0VLFuRMN+lP1xvpNZHCRNM4fBzn1jg==}
 
-  '@motionone/types@10.17.0':
-    resolution: {integrity: sha512-EgeeqOZVdRUTEHq95Z3t8Rsirc7chN5xFAPMYFobx8TPubkEfRSm5xihmMUkbaR2ErKJTUw3347QDPTHIW12IA==}
+  '@motionone/types@10.17.1':
+    resolution: {integrity: sha512-KaC4kgiODDz8hswCrS0btrVrzyU2CSQKO7Ps90ibBVSQmjkrt2teqta6/sOG59v7+dPnKMAg13jyqtMKV2yJ7A==}
 
-  '@motionone/utils@10.17.0':
-    resolution: {integrity: sha512-bGwrki4896apMWIj9yp5rAS2m0xyhxblg6gTB/leWDPt+pb410W8lYWsxyurX+DH+gO1zsQsfx2su/c1/LtTpg==}
+  '@motionone/utils@10.18.0':
+    resolution: {integrity: sha512-3XVF7sgyTSI2KWvTf6uLlBJ5iAgRgmvp3bpuOiQJvInd4nZ19ET8lX5unn30SlmRH7hXbBbH+Gxd0m0klJ3Xtw==}
 
   '@nicolo-ribaudo/chokidar-2@2.1.8-no-fsevents.3':
     resolution: {integrity: sha512-s88O1aVtXftvp5bCPB7WnmXc5IwOZZ7YPuwNPt+GtOOXpPvad1LfbmjYv+qII7zP6RU2QGnqve27dnLycEnyEQ==}
@@ -2776,8 +2776,8 @@ packages:
   core-js-compat@3.38.1:
     resolution: {integrity: sha512-JRH6gfXxGmrzF3tZ57lFx97YARxCXPaMzPo6jELZhv88pBH5VXpQ+y0znKGlFnzuaihqhLbefxSJxWJMPtfDzw==}
 
-  core-js@3.35.1:
-    resolution: {integrity: sha512-IgdsbxNyMskrTFxa9lWHyMwAJU5gXOPP+1yO+K59d50VLVAIDAbs7gIv705KzALModfK3ZrSZTPNpC0PQgIZuw==}
+  core-js@3.39.0:
+    resolution: {integrity: sha512-raM0ew0/jJUqkJ0E6e8UDtl+y/7ktFivgWvqw8dNSQeNWoSDLvQ1H/RN3aPXB9tBd4/FhyR4RDPGhsNIMsAn7g==}
 
   cross-spawn@7.0.3:
     resolution: {integrity: sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==}
@@ -3237,8 +3237,8 @@ packages:
     resolution: {integrity: sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==}
     engines: {node: '>= 6'}
 
-  formik@2.4.5:
-    resolution: {integrity: sha512-Gxlht0TD3vVdzMDHwkiNZqJ7Mvg77xQNfmBRrNtvzcHZs72TJppSTDKHpImCMJZwcWPBJ8jSQQ95GJzXFf1nAQ==}
+  formik@2.4.6:
+    resolution: {integrity: sha512-A+2EI7U7aG296q2TLGvNapDNTZp1khVt5Vk0Q/fyfSROss0V/V6+txt2aJnwEos44IxTCW/LYAi/zgWzlevj+g==}
     peerDependencies:
       react: '>=16.8.0'
 
@@ -3419,8 +3419,8 @@ packages:
   hey-listen@1.0.8:
     resolution: {integrity: sha512-COpmrF2NOg4TBWUJ5UVyaCU2A88wEMkUPK4hNqyCkqHbxT92BbvfjoSozkAIIm6XhicGlJHhFdullInrdhwU8Q==}
 
-  highlight-words-core@1.2.2:
-    resolution: {integrity: sha512-BXUKIkUuh6cmmxzi5OIbUJxrG8OAk2MqoL1DtO3Wo9D2faJg2ph5ntyuQeLqaHJmzER6H5tllCDA9ZnNe9BVGg==}
+  highlight-words-core@1.2.3:
+    resolution: {integrity: sha512-m1O9HW3/GNHxzSIXWw1wCNXXsgLlxrP0OI6+ycGUhiUHkikqW3OrwVHz+lxeNBe5yqLESdIcj8PowHQ2zLvUvQ==}
 
   hoist-non-react-statics@3.3.2:
     resolution: {integrity: sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==}
@@ -4313,6 +4313,9 @@ packages:
   picocolors@1.0.1:
     resolution: {integrity: sha512-anP1Z8qwhkbmu7MFP5iTt+wQKXgwzf7zTyGlcdzabySa9vd0Xt392U0rVmz9poOaBj0uHJKyyo9/upk0HrEQew==}
 
+  picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
   picomatch@2.3.1:
     resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
     engines: {node: '>=8.6'}
@@ -4703,6 +4706,9 @@ packages:
   react-is@18.2.0:
     resolution: {integrity: sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==}
 
+  react-is@18.3.1:
+    resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
+
   react-popper@2.3.0:
     resolution: {integrity: sha512-e1hj8lL3uM+sgSR4Lxzn5h1GxBlpa4CQz0XLF8kx4MDrDRWY0Ena4c97PUeSX9i5W3UAfDP0z0FXCTQkoXUl3Q==}
     peerDependencies:
@@ -4886,8 +4892,8 @@ packages:
     engines: {node: '>=10.0.0'}
     hasBin: true
 
-  rollup@3.29.4:
-    resolution: {integrity: sha512-oWzmBZwvYrU0iJHtDmhsm662rC15FRXmcjCk1xD771dFDx5jJ02ufAQQTn0etB2emNk4J9EZg/yWKpsn9BWGRw==}
+  rollup@3.29.5:
+    resolution: {integrity: sha512-GVsDdsbJzzy4S/v3dqWPJ7EfvZJfCHiDqe80IyrF59LYuP+e6U1LJoUqeuqRbwAWoMNoXivMNeNAOf5E22VA1w==}
     engines: {node: '>=14.18.0', npm: '>=8.0.0'}
     hasBin: true
 
@@ -5009,6 +5015,10 @@ packages:
 
   source-map-js@1.2.0:
     resolution: {integrity: sha512-itJW8lvSA0TXEphiRoawsCksnlf8SyvmFzIhltqAHluXd88pkCd+cXJVHTDwdCr0IzwptSm035IHQktUu1QUMg==}
+    engines: {node: '>=0.10.0'}
+
+  source-map-js@1.2.1:
+    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
 
   source-map-support@0.5.21:
@@ -7241,7 +7251,7 @@ snapshots:
 
   '@bcoe/v8-coverage@0.2.3': {}
 
-  '@deskpro/deskpro-ui@7.18.0(@types/web@0.0.111)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(styled-components@5.3.11(@babel/core@7.16.0)(react-dom@18.2.0(react@18.2.0))(react-is@18.2.0)(react@18.2.0))':
+  '@deskpro/deskpro-ui@8.0.0(@types/web@0.0.111)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(styled-components@5.3.11(@babel/core@7.16.0)(react-dom@18.2.0(react@18.2.0))(react-is@18.3.1)(react@18.2.0))':
     dependencies:
       '@fortawesome/fontawesome-svg-core': 6.5.1
       '@fortawesome/free-solid-svg-icons': 6.5.1
@@ -7252,18 +7262,18 @@ snapshots:
       '@typescript/lib-dom': '@types/web@0.0.111'
       csstype: 3.1.3
       d3-hierarchy: 3.1.2
-      formik: 2.4.5(react@18.2.0)
+      formik: 2.4.6(react@18.2.0)
       framer-motion: 6.5.1(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       lodash: 4.17.21
       pretty-bytes: 6.1.1
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       react-highlight-words: 0.17.0(react@18.2.0)
-      react-is: 17.0.2
+      react-is: 18.3.1
       react-popper: 2.3.0(@popperjs/core@2.11.8)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       simplebar: 5.3.9
       simplebar-react: 2.4.3(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
-      styled-components: 5.3.11(@babel/core@7.16.0)(react-dom@18.2.0(react@18.2.0))(react-is@18.2.0)(react@18.2.0)
+      styled-components: 5.3.11(@babel/core@7.16.0)(react-dom@18.2.0(react@18.2.0))(react-is@18.3.1)(react@18.2.0)
       tippy.js: 6.3.7
       ts-pattern: 4.3.0
       tslib: 2.4.1
@@ -7694,40 +7704,40 @@ snapshots:
       '@types/react': 18.2.51
       react: 18.2.0
 
-  '@motionone/animation@10.17.0':
+  '@motionone/animation@10.18.0':
     dependencies:
-      '@motionone/easing': 10.17.0
-      '@motionone/types': 10.17.0
-      '@motionone/utils': 10.17.0
-      tslib: 2.3.1
+      '@motionone/easing': 10.18.0
+      '@motionone/types': 10.17.1
+      '@motionone/utils': 10.18.0
+      tslib: 2.4.1
 
   '@motionone/dom@10.12.0':
     dependencies:
-      '@motionone/animation': 10.17.0
-      '@motionone/generators': 10.17.0
-      '@motionone/types': 10.17.0
-      '@motionone/utils': 10.17.0
+      '@motionone/animation': 10.18.0
+      '@motionone/generators': 10.18.0
+      '@motionone/types': 10.17.1
+      '@motionone/utils': 10.18.0
       hey-listen: 1.0.8
-      tslib: 2.3.1
+      tslib: 2.4.1
 
-  '@motionone/easing@10.17.0':
+  '@motionone/easing@10.18.0':
     dependencies:
-      '@motionone/utils': 10.17.0
-      tslib: 2.3.1
+      '@motionone/utils': 10.18.0
+      tslib: 2.4.1
 
-  '@motionone/generators@10.17.0':
+  '@motionone/generators@10.18.0':
     dependencies:
-      '@motionone/types': 10.17.0
-      '@motionone/utils': 10.17.0
-      tslib: 2.3.1
+      '@motionone/types': 10.17.1
+      '@motionone/utils': 10.18.0
+      tslib: 2.4.1
 
-  '@motionone/types@10.17.0': {}
+  '@motionone/types@10.17.1': {}
 
-  '@motionone/utils@10.17.0':
+  '@motionone/utils@10.18.0':
     dependencies:
-      '@motionone/types': 10.17.0
+      '@motionone/types': 10.17.1
       hey-listen: 1.0.8
-      tslib: 2.3.1
+      tslib: 2.4.1
 
   '@nicolo-ribaudo/chokidar-2@2.1.8-no-fsevents.3':
     optional: true
@@ -8633,14 +8643,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  babel-plugin-styled-components@2.1.4(@babel/core@7.16.0)(styled-components@5.3.11(@babel/core@7.16.0)(react-dom@18.2.0(react@18.2.0))(react-is@18.2.0)(react@18.2.0)):
+  babel-plugin-styled-components@2.1.4(@babel/core@7.16.0)(styled-components@5.3.11(@babel/core@7.16.0)(react-dom@18.2.0(react@18.2.0))(react-is@18.3.1)(react@18.2.0)):
     dependencies:
       '@babel/helper-annotate-as-pure': 7.22.5
       '@babel/helper-module-imports': 7.22.15
       '@babel/plugin-syntax-jsx': 7.23.3(@babel/core@7.16.0)
       lodash: 4.17.21
       picomatch: 2.3.1
-      styled-components: 5.3.11(@babel/core@7.16.0)(react-dom@18.2.0(react@18.2.0))(react-is@18.2.0)(react@18.2.0)
+      styled-components: 5.3.11(@babel/core@7.16.0)(react-dom@18.2.0(react@18.2.0))(react-is@18.3.1)(react@18.2.0)
     transitivePeerDependencies:
       - '@babel/core'
 
@@ -8912,7 +8922,7 @@ snapshots:
     dependencies:
       browserslist: 4.23.3
 
-  core-js@3.35.1: {}
+  core-js@3.39.0: {}
 
   cross-spawn@7.0.3:
     dependencies:
@@ -9478,7 +9488,7 @@ snapshots:
       combined-stream: 1.0.8
       mime-types: 2.1.35
 
-  formik@2.4.5(react@18.2.0):
+  formik@2.4.6(react@18.2.0):
     dependencies:
       '@types/hoist-non-react-statics': 3.3.5
       deepmerge: 2.2.1
@@ -9488,7 +9498,7 @@ snapshots:
       react: 18.2.0
       react-fast-compare: 2.0.4
       tiny-warning: 1.0.3
-      tslib: 2.3.1
+      tslib: 2.4.1
 
   forwarded@0.2.0: {}
 
@@ -9501,13 +9511,13 @@ snapshots:
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       style-value-types: 5.0.0
-      tslib: 2.3.1
+      tslib: 2.4.1
     optionalDependencies:
       '@emotion/is-prop-valid': 0.8.8
 
   framesync@6.0.1:
     dependencies:
-      tslib: 2.3.1
+      tslib: 2.4.1
 
   fresh@0.5.2: {}
 
@@ -9689,7 +9699,7 @@ snapshots:
 
   hey-listen@1.0.8: {}
 
-  highlight-words-core@1.2.2: {}
+  highlight-words-core@1.2.3: {}
 
   hoist-non-react-statics@3.3.2:
     dependencies:
@@ -10787,6 +10797,8 @@ snapshots:
 
   picocolors@1.0.1: {}
 
+  picocolors@1.1.1: {}
+
   picomatch@2.3.1: {}
 
   pify@4.0.1: {}
@@ -10812,7 +10824,7 @@ snapshots:
       framesync: 6.0.1
       hey-listen: 1.0.8
       style-value-types: 5.0.0
-      tslib: 2.3.1
+      tslib: 2.4.1
 
   postcss-calc@8.2.4(postcss@8.4.38):
     dependencies:
@@ -11012,8 +11024,8 @@ snapshots:
   postcss@8.4.38:
     dependencies:
       nanoid: 3.3.7
-      picocolors: 1.0.1
-      source-map-js: 1.2.0
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
 
   prelude-ls@1.2.1: {}
 
@@ -11141,7 +11153,7 @@ snapshots:
 
   react-highlight-words@0.17.0(react@18.2.0):
     dependencies:
-      highlight-words-core: 1.2.2
+      highlight-words-core: 1.2.3
       memoize-one: 4.0.3
       prop-types: 15.8.1
       react: 18.2.0
@@ -11169,6 +11181,8 @@ snapshots:
   react-is@18.1.0: {}
 
   react-is@18.2.0: {}
+
+  react-is@18.3.1: {}
 
   react-popper@2.3.0(@popperjs/core@2.11.8)(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
     dependencies:
@@ -11396,7 +11410,7 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.3
 
-  rollup@3.29.4:
+  rollup@3.29.5:
     optionalDependencies:
       fsevents: 2.3.3
 
@@ -11517,7 +11531,7 @@ snapshots:
     dependencies:
       '@juggle/resize-observer': 3.4.0
       can-use-dom: 0.1.0
-      core-js: 3.35.1
+      core-js: 3.39.0
       lodash.debounce: 4.0.8
       lodash.memoize: 4.1.2
       lodash.throttle: 4.1.1
@@ -11536,6 +11550,8 @@ snapshots:
   slash@5.1.0: {}
 
   source-map-js@1.2.0: {}
+
+  source-map-js@1.2.1: {}
 
   source-map-support@0.5.21:
     dependencies:
@@ -11642,21 +11658,21 @@ snapshots:
   style-value-types@5.0.0:
     dependencies:
       hey-listen: 1.0.8
-      tslib: 2.3.1
+      tslib: 2.4.1
 
-  styled-components@5.3.11(@babel/core@7.16.0)(react-dom@18.2.0(react@18.2.0))(react-is@18.2.0)(react@18.2.0):
+  styled-components@5.3.11(@babel/core@7.16.0)(react-dom@18.2.0(react@18.2.0))(react-is@18.3.1)(react@18.2.0):
     dependencies:
       '@babel/helper-module-imports': 7.22.15
       '@babel/traverse': 7.23.9(supports-color@5.5.0)
       '@emotion/is-prop-valid': 1.2.1
       '@emotion/stylis': 0.8.5
       '@emotion/unitless': 0.7.5
-      babel-plugin-styled-components: 2.1.4(@babel/core@7.16.0)(styled-components@5.3.11(@babel/core@7.16.0)(react-dom@18.2.0(react@18.2.0))(react-is@18.2.0)(react@18.2.0))
+      babel-plugin-styled-components: 2.1.4(@babel/core@7.16.0)(styled-components@5.3.11(@babel/core@7.16.0)(react-dom@18.2.0(react@18.2.0))(react-is@18.3.1)(react@18.2.0))
       css-to-react-native: 3.2.0
       hoist-non-react-statics: 3.3.2
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-      react-is: 18.2.0
+      react-is: 18.3.1
       shallowequal: 1.1.0
       supports-color: 5.5.0
     transitivePeerDependencies:
@@ -11943,7 +11959,7 @@ snapshots:
     dependencies:
       esbuild: 0.18.20
       postcss: 8.4.38
-      rollup: 3.29.4
+      rollup: 3.29.5
     optionalDependencies:
       '@types/node': 20.11.15
       fsevents: 2.3.3


### PR DESCRIPTION
This bumps `@deskpro/deskpro-ui` which has better font optimisations which will then in turn bring down apps sizes. This is nice for everyone but double-so for on-prem customers.

# Breaking Change (Major version bump)
As per the change on `@deskpro/deskpro-ui` [this will drop support for IE11.](https://github.com/deskpro/deskpro-ui/pull/388) due to fonts only been in `woff2` format.

# Minor Change
Use `pnpm` instead of `npm` in CI for Docs, Version Bumping, and Publishing