### PR TITLE
[Feature] SC-169459 apps allow-apps to explicitly set the headers they want to proxy

### DIFF
--- a/src/proxy/helpers.ts
+++ b/src/proxy/helpers.ts
@@ -15,7 +15,7 @@ export const proxyFetch: ProxyFetch = async (client: IDeskproClient): Promise<Fe
     ...init,
     method: "POST",
     headers: {
-      ...(init?.headers ?? {}),
+      "x-Proxy-Headers": JSON.stringify(init?.headers ?? {}),
       "X-Proxy-Authorization": `Bearer ${token}`,
       "X-Proxy-Url": typeof input === "string" ? input : input.url,
       "X-Proxy-Method": typeof input === "string" ? (init?.method ?? "GET") : input.method,
@@ -38,7 +38,7 @@ export const adminGenericProxyFetch: ProxyFetch = async (client: IDeskproClient)
     ...init,
     method: "POST",
     headers: {
-      ...(init?.headers ?? {}),
+      "x-Proxy-Headers": JSON.stringify(init?.headers ?? {}),
       "X-Proxy-Authorization": `Bearer ${token}`,
       "X-Proxy-Url": typeof input === "string" ? input : input.url,
       "X-Proxy-Method": typeof input === "string" ? (init?.method ?? "GET") : input.method,


### PR DESCRIPTION
Relates to: https://github.com/deskpro/deskpro-product/pull/16049

This sends the headers as a JSON encoded string in the `x-proxy-headers` so that it's clear what headers the developer wants to send to the end user and what's inferred. Previously developers could specify which headers they want to send but the browser would append their own (which is normal and expected but not desirable)