### PR TITLE
[Feature] SC-170716 Allow apps to pull themselves into focus using API

### DIFF
--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -245,6 +245,7 @@ export class DeskproClient implements IDeskproClient {
   // Sidebar Methods
   public setBadgeCount: (count: number) => void;
   public setTitle: (title: string) => void;
+  public focus: () => void;
 
   // EntityAssociation
   public entityAssociationSet: (entityId: string, name: string, key: string, value?: string) => Promise<void>;
@@ -300,6 +301,7 @@ export class DeskproClient implements IDeskproClient {
     this.deregisterElement = () => {};
     this.setBadgeCount = () => {};
     this.setTitle = () => {};
+    this.focus = () => {};
 
     this.entityAssociationSet = async () => {};
     this.entityAssociationDelete = async () => {};
@@ -387,6 +389,10 @@ export class DeskproClient implements IDeskproClient {
 
     if (parent.setTitle) {
       this.setTitle = parent.setTitle;
+    }
+
+    if (parent.focus) {
+      this.focus = parent.focus;
     }
 
     // Entity Association

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -185,6 +185,7 @@ export type ChildMethods = {
 
 export interface TicketSidebarDeskproCallSender {
   setTitle: (title: string) => void;
+  focus: () => void;
   setBadgeCount: (count: number) => void;
 }
 
@@ -323,6 +324,7 @@ export interface IDeskproClient {
   onElementEvent: (cb: ElementEventChildMethod) => void;
   setBadgeCount: (count: number) => void;
   setTitle: (title: string) => void;
+  focus: () => void;
   entityAssociationGet: (entityId: string, name: string, key: string) => Promise<string|null>;
   entityAssociationSet: (entityId: string, name: string, key: string, value?: string) => Promise<void>;
   entityAssociationDelete: (entityId: string, name: string, key: string) => Promise<void>;

--- a/tests/client/client.test.ts
+++ b/tests/client/client.test.ts
@@ -39,6 +39,7 @@ test("run() mount core methods", async () => {
   const setHeightMock = jest.fn();
   const setBadgeCountMock = jest.fn();
   const getTitleMock = jest.fn();
+  const focusMock = jest.fn();
 
   const parent = jest.fn().mockReturnValue({
     promise: new Promise((resolve) => {
@@ -47,6 +48,7 @@ test("run() mount core methods", async () => {
         _setHeight: setHeightMock,
         setBadgeCount: setBadgeCountMock,
         setTitle: getTitleMock,
+        focus: focusMock,
       });
     }),
   });
@@ -57,4 +59,5 @@ test("run() mount core methods", async () => {
   expect(client.resize).toBeTruthy();
   expect(client.setBadgeCount).toBeTruthy();
   expect(client.setTitle).toBeTruthy();
+  expect(client.focus).toBeTruthy();
 });


### PR DESCRIPTION
This change introduces `.focus` into the APP-SDK so that apps can pull themselves into focus.

Example use cases;

1. Calendar app to remind you of upcoming event(s)
2. Voice/Phone app when you receive a call
3. Ticket system app to get your attention when a P0 ticket has been raised