### PR TITLE
[Feature] SC-170760 Allow Apps to open up contacts using `.openContact`

### DIFF
--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -246,6 +246,7 @@ export class DeskproClient implements IDeskproClient {
   public setBadgeCount: (count: number) => void;
   public setTitle: (title: string) => void;
   public focus: () => void;
+  public openContact: (contact: Partial<{id: number, email: string, phoneNumber: string}>) => void;
 
   // EntityAssociation
   public entityAssociationSet: (entityId: string, name: string, key: string, value?: string) => Promise<void>;
@@ -302,6 +303,7 @@ export class DeskproClient implements IDeskproClient {
     this.setBadgeCount = () => {};
     this.setTitle = () => {};
     this.focus = () => {};
+    this.openContact = () => {};
 
     this.entityAssociationSet = async () => {};
     this.entityAssociationDelete = async () => {};
@@ -393,6 +395,10 @@ export class DeskproClient implements IDeskproClient {
 
     if (parent.focus) {
       this.focus = parent.focus;
+    }
+
+    if (parent.openContact) {
+      this.openContact = parent._openContact;
     }
 
     // Entity Association

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -246,7 +246,7 @@ export class DeskproClient implements IDeskproClient {
   public setBadgeCount: (count: number) => void;
   public setTitle: (title: string) => void;
   public focus: () => void;
-  public openContact: (contact: Partial<{id: number, email: string, phoneNumber: string}>) => void;
+  public openContact: (contact: Partial<{id: number, emailAddress: string, phoneNumber: string}>) => void;
 
   // EntityAssociation
   public entityAssociationSet: (entityId: string, name: string, key: string, value?: string) => Promise<void>;
@@ -398,7 +398,7 @@ export class DeskproClient implements IDeskproClient {
     }
 
     if (parent.openContact) {
-      this.openContact = parent._openContact;
+      this.openContact = parent.openContact;
     }
 
     // Entity Association

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -186,7 +186,7 @@ export type ChildMethods = {
 export interface TicketSidebarDeskproCallSender {
   setTitle: (title: string) => void;
   focus: () => void;
-  openContact: (contact: Partial<{id: number, email: string, phoneNumber: string}>) => void;
+  openContact: (contact: Partial<{id: number, emailAddress: string, phoneNumber: string}>) => void;
   setBadgeCount: (count: number) => void;
 }
 
@@ -326,7 +326,7 @@ export interface IDeskproClient {
   setBadgeCount: (count: number) => void;
   setTitle: (title: string) => void;
   focus: () => void;
-  openContact: (contact: Partial<{id: number, email: string, phoneNumber: string}>) => void;
+  openContact: (contact: Partial<{id: number, emailAddress: string, phoneNumber: string}>) => void;
   entityAssociationGet: (entityId: string, name: string, key: string) => Promise<string|null>;
   entityAssociationSet: (entityId: string, name: string, key: string, value?: string) => Promise<void>;
   entityAssociationDelete: (entityId: string, name: string, key: string) => Promise<void>;

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -186,6 +186,7 @@ export type ChildMethods = {
 export interface TicketSidebarDeskproCallSender {
   setTitle: (title: string) => void;
   focus: () => void;
+  openContact: (contact: Partial<{id: number, email: string, phoneNumber: string}>) => void;
   setBadgeCount: (count: number) => void;
 }
 
@@ -325,6 +326,7 @@ export interface IDeskproClient {
   setBadgeCount: (count: number) => void;
   setTitle: (title: string) => void;
   focus: () => void;
+  openContact: (contact: Partial<{id: number, email: string, phoneNumber: string}>) => void;
   entityAssociationGet: (entityId: string, name: string, key: string) => Promise<string|null>;
   entityAssociationSet: (entityId: string, name: string, key: string, value?: string) => Promise<void>;
   entityAssociationDelete: (entityId: string, name: string, key: string) => Promise<void>;


### PR DESCRIPTION
Some apps have some partial user data, like voice/phone apps, and they need a way to open up the contact directly in Deskpro so that the agent/admin has all the information they need, directly right there and then.

Options support as of day one include (but may be extended in the future) to;

1. `id`: the deskpro internal contact id
2. `phoneNumber`: the contacts phone number
3. `emailAddress`: the contacts email address