### PR TITLE
[Feature] SC-153656 Allow Global Apps to be closed/Unfocused

### DIFF
--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -246,6 +246,7 @@ export class DeskproClient implements IDeskproClient {
   public setBadgeCount: (count: number) => void;
   public setTitle: (title: string) => void;
   public focus: () => void;
+  public unfocus: () => void;
   public openContact: (contact: Partial<{id: number, emailAddress: string, phoneNumber: string}>) => void;
 
   // EntityAssociation
@@ -303,6 +304,7 @@ export class DeskproClient implements IDeskproClient {
     this.setBadgeCount = () => {};
     this.setTitle = () => {};
     this.focus = () => {};
+    this.unfocus = () => {};
     this.openContact = () => {};
 
     this.entityAssociationSet = async () => {};
@@ -395,6 +397,10 @@ export class DeskproClient implements IDeskproClient {
 
     if (parent.focus) {
       this.focus = parent.focus;
+    }
+
+    if (parent.unfocus) {
+      this.unfocus = parent.unfocus;
     }
 
     if (parent.openContact) {

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -326,6 +326,7 @@ export interface IDeskproClient {
   setBadgeCount: (count: number) => void;
   setTitle: (title: string) => void;
   focus: () => void;
+  unfocus: () => void;
   openContact: (contact: Partial<{id: number, emailAddress: string, phoneNumber: string}>) => void;
   entityAssociationGet: (entityId: string, name: string, key: string) => Promise<string|null>;
   entityAssociationSet: (entityId: string, name: string, key: string, value?: string) => Promise<void>;

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -185,7 +185,6 @@ export type ChildMethods = {
 
 export interface TicketSidebarDeskproCallSender {
   setTitle: (title: string) => void;
-  focus: () => void;
   openContact: (contact: Partial<{id: number, emailAddress: string, phoneNumber: string}>) => void;
   setBadgeCount: (count: number) => void;
 }
@@ -193,6 +192,8 @@ export interface TicketSidebarDeskproCallSender {
 export interface CoreCallSender {
   _setHeight: (height: number) => void;
   _setWidth: (width: number | string) => void;
+  focus: () => void;
+  unfocus: () => void;
   _registerElement: (id: string, element: AppElement) => Promise<void>;
   _deregisterElement: (id: string) => Promise<void>;
   _getProxyAuth: () => Promise<ProxyAuthPayload>;


### PR DESCRIPTION
_This PR is paired with: https://github.com/deskpro/deskpro-product/pull/16303_
This allows apps to close themselves. For example, you update a ticket in your 3rd party and would like to auto-hide the app. Another example in a phone/voice app, if a user hangs up, it can auto close.