### PR TITLE
Manually allow stopping oauth2 polling

### DIFF
--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -505,6 +505,7 @@ export class DeskproClient implements IDeskproClient {
     return {
       poll,
       authorizationUrl: authorizeUrl,
+      stopPolling: clearInterval(pollInterval),
     };
   }
 
@@ -544,6 +545,7 @@ export class DeskproClient implements IDeskproClient {
     return {
       poll,
       authorizationUrl: start.authorizationUrl,
+      stopPolling: clearInterval(pollInterval),
     };
   }
 

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -356,6 +356,7 @@ export interface IDeskproClient {
 export interface IOAuth2 {
   poll: () => Promise<OAuth2Result>;
   authorizationUrl: string;
+  stopPolling: void;
 }
 
 export interface OAuth2Result {


### PR DESCRIPTION
Allow manually stopping of OAuth2 polling. This is useful if you change some settings, you don't want 2 or 3 or more pollings happening at the same time.

It doesn't automatically stop invoking because it is possible that you want to OAuth2 multiple different clients at the same time.